### PR TITLE
Adding Weller to the groups list

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -372,6 +372,7 @@ a:hover {
     justify-content: left;
     z-index: inherit;
     margin: auto;
+    overflow-y: auto;
 }
 
 .menu-item {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -372,7 +372,6 @@ a:hover {
     justify-content: left;
     z-index: inherit;
     margin: auto;
-    overflow-y: auto;
 }
 
 .menu-item {

--- a/content/people/aw665.md
+++ b/content/people/aw665.md
@@ -13,7 +13,7 @@ draft: false
 google_scholar: "https://scholar.google.co.uk/citations?hl=en&user=Ek4hM10AAAAJ"
 labs: ["cbl"]
 ---
-Adrian Weller is a principal research fellow in  [machine learning](http://mlg.eng.cam.ac.uk/) at the University of Cambridge. 
+Adrian Weller is a Director of Research in  [machine learning](http://mlg.eng.cam.ac.uk/) at the University of Cambridge. 
 
 <!--, in the Computational and Biological
 Learning Lab. <!--, advised by Prof Zoubin Ghahramani. 

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -40,7 +40,7 @@ function groups() {
   if (x.className === "menu-item dropdown-hidden") {
     x.className = "menu-item dropdown";
     y.style.maxWidth = "15em";
-    y.style.maxHeight = "19em";
+    y.style.maxHeight = "21em";
     y.style.opacity = "100%";
   } else {
     x.className = "menu-item dropdown-hidden";

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,6 +47,7 @@
                         <a href="http://mlg.eng.cam.ac.uk/">RASMUSSEN</a>
                         <a href="http://cbl.eng.cam.ac.uk/Public/Turner/WebHome/">TURNER</a>
                         <a href="http://mlg.eng.cam.ac.uk/">GE</a>
+                        <a href="https://mlg.eng.cam.ac.uk/adrian/">WELLER</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Added Weller to the groups list and updated Adrian's title.
~With this addition, half of Weller's group's text will be outside the "Groups" dropdown menu. So I added scrolling to the menu.~
~It'd be great if it can be displayed without scrolling, but I don't know how to do it.~